### PR TITLE
Add functionality for `yield` and `yield from`

### DIFF
--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -13,7 +13,7 @@ const group = docBuilders.group;
 const indent = docBuilders.indent;
 const ifBreak = docBuilders.ifBreak;
 
-const unenclosedSpace = concat([ifBreak(" \\"), line]);
+const escapedLine = concat([ifBreak(" \\"), line]);
 
 function printPythonString(raw, options) {
   // `rawContent` is the string exactly like it appeared in the input source
@@ -709,7 +709,7 @@ function genericPrint(path, options, print) {
       return group(
         concat([
           "yield",
-          indent(concat([unenclosedSpace, path.call(print, "value")]))
+          indent(concat([escapedLine, path.call(print, "value")]))
         ])
       );
     }
@@ -718,7 +718,7 @@ function genericPrint(path, options, print) {
       return group(
         concat([
           "yield from",
-          indent(concat([unenclosedSpace, path.call(print, "value")]))
+          indent(concat([escapedLine, path.call(print, "value")]))
         ])
       );
     }

--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -11,6 +11,9 @@ const line = docBuilders.line;
 const softline = docBuilders.softline;
 const group = docBuilders.group;
 const indent = docBuilders.indent;
+const ifBreak = docBuilders.ifBreak;
+
+const unenclosedSpace = concat([ifBreak(" \\"), line]);
 
 function printPythonString(raw, options) {
   // `rawContent` is the string exactly like it appeared in the input source
@@ -703,11 +706,21 @@ function genericPrint(path, options, print) {
     }
 
     case "Yield": {
-      return group(concat(["yield", line, path.call(print, "value")]));
+      return group(
+        concat([
+          "yield",
+          indent(concat([unenclosedSpace, path.call(print, "value")]))
+        ])
+      );
     }
 
     case "YieldFrom": {
-      return group(concat(["yield from", line, path.call(print, "value")]));
+      return group(
+        concat([
+          "yield from",
+          indent(concat([unenclosedSpace, path.call(print, "value")]))
+        ])
+      );
     }
 
     /* istanbul ignore next */

--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -725,10 +725,6 @@ function genericPrint(path, options, print) {
 
     /* istanbul ignore next */
     default:
-      if (global.isInTest) {
-        throw "Unknown Python node: " +
-          JSON.stringify(n, null /*replacer*/, 4 /*space*/);
-      }
       // eslint-disable-next-line no-console
       console.error("Unknown Python node:", n);
       return n.source;

--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -702,8 +702,20 @@ function genericPrint(path, options, print) {
       return group(concat(parts));
     }
 
+    case "Yield": {
+      return group(concat(["yield", line, path.call(print, "value")]));
+    }
+
+    case "YieldFrom": {
+      return group(concat(["yield from", line, path.call(print, "value")]));
+    }
+
     /* istanbul ignore next */
     default:
+      if (global.isInTest) {
+        throw "Unknown Python node: " +
+          JSON.stringify(n, null /*replacer*/, 4 /*space*/);
+      }
       // eslint-disable-next-line no-console
       console.error("Unknown Python node:", n);
       return n.source;

--- a/tests/python_yield/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_yield/__snapshots__/jsfmt.spec.js.snap
@@ -6,12 +6,28 @@ def example(first):
         yield
 
     yield first
+
+
+def should_wrap():
+    yield very_long_variable_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+
+def should_unwrap():
+    yield \\
+        short_variable_name
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 def example(first):
     if False:
         yield
 
     yield first
+
+def should_wrap():
+    yield \\
+        very_long_variable_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+def should_unwrap():
+    yield short_variable_name
 
 `;
 
@@ -21,11 +37,27 @@ def example(first):
         yield
 
     yield first
+
+
+def should_wrap():
+    yield very_long_variable_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+
+def should_unwrap():
+    yield \\
+        short_variable_name
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 def example(first):
     if False:
         yield
 
     yield first
+
+def should_wrap():
+    yield \\
+        very_long_variable_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+def should_unwrap():
+    yield short_variable_name
 
 `;

--- a/tests/python_yield/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_yield/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`yield.py 1`] = `
+def example(first):
+    if False:
+        yield
+
+    yield first
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+def example(first):
+    if False:
+        yield
+
+    yield first
+
+`;
+
+exports[`yield.py 2`] = `
+def example(first):
+    if False:
+        yield
+
+    yield first
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+def example(first):
+    if False:
+        yield
+
+    yield first
+
+`;

--- a/tests/python_yield/jsfmt.spec.js
+++ b/tests/python_yield/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname, ["python"], { pythonVersion: "2" });
+run_spec(__dirname, ["python"], { pythonVersion: "3" });

--- a/tests/python_yield/yield.py
+++ b/tests/python_yield/yield.py
@@ -1,0 +1,5 @@
+def example(first):
+    if False:
+        yield
+
+    yield first

--- a/tests/python_yield/yield.py
+++ b/tests/python_yield/yield.py
@@ -3,3 +3,12 @@ def example(first):
         yield
 
     yield first
+
+
+def should_wrap():
+    yield very_long_variable_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+
+def should_unwrap():
+    yield \
+        short_variable_name

--- a/tests/python_yield_from/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_yield_from/__snapshots__/jsfmt.spec.js.snap
@@ -3,8 +3,24 @@
 exports[`yield_from.py 1`] = `
 def example(first):
     yield from first
+
+
+def should_wrap():
+    yield from very_long_variable_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+
+def should_unwrap():
+    yield from \\
+        short_variable_name
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 def example(first):
     yield from first
+
+def should_wrap():
+    yield from \\
+        very_long_variable_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+def should_unwrap():
+    yield from short_variable_name
 
 `;

--- a/tests/python_yield_from/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_yield_from/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`yield_from.py 1`] = `
+def example(first):
+    yield from first
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+def example(first):
+    yield from first
+
+`;

--- a/tests/python_yield_from/jsfmt.spec.js
+++ b/tests/python_yield_from/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["python"], { pythonVersion: "3" });

--- a/tests/python_yield_from/yield_from.py
+++ b/tests/python_yield_from/yield_from.py
@@ -1,0 +1,2 @@
+def example(first):
+    yield from first

--- a/tests/python_yield_from/yield_from.py
+++ b/tests/python_yield_from/yield_from.py
@@ -1,2 +1,11 @@
 def example(first):
     yield from first
+
+
+def should_wrap():
+    yield from very_long_variable_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+
+def should_unwrap():
+    yield from \
+        short_variable_name

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -9,7 +9,6 @@ const normalizeOptions = require("prettier/src/main/options").normalize;
 const AST_COMPARE = process.env["AST_COMPARE"];
 
 function run_spec(dirname, parsers, options) {
-  global.isInTest = true;
   options = Object.assign(
     {
       plugins: ["."],

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -9,6 +9,7 @@ const normalizeOptions = require("prettier/src/main/options").normalize;
 const AST_COMPARE = process.env["AST_COMPARE"];
 
 function run_spec(dirname, parsers, options) {
+  global.isInTest = true;
   options = Object.assign(
     {
       plugins: ["."],


### PR DESCRIPTION
This adds tests to ensure that `yield` and `yield from` AST nodes are understood and printed properly, and implements the printing for those nodes. This also modifies the printer to throw when it encounters an unknown node type so that the tests actually fail before the behavior is implemented.