### PR TITLE
Clean up wrapping of lambdas and function declarations

### DIFF
--- a/tests/python_lambdas/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_lambdas/__snapshots__/jsfmt.spec.js.snap
@@ -2,18 +2,66 @@
 
 exports[`lambdas.py 1`] = `
 key=lambda variable: variable[0]
-max(lis, key=lambda x:int(x))~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+max(lis, key=lambda x:int(x))
+f = lambda param: some_very_long_variable_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+f = lambda some_very_long_param_name_1_aaaaaaaaaa, some_very_long_param_name_2_aaaaaaaaaa, some_very_long_param_name_3_aaaaaaaaaa: True
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 key = lambda variable: variable[0]
 
 max(lis, key=lambda x: int(x))
+
+f = lambda param: \\
+        some_very_long_variable_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+f = lambda \\
+        some_very_long_param_name_1_aaaaaaaaaa, \\
+        some_very_long_param_name_2_aaaaaaaaaa, \\
+        some_very_long_param_name_3_aaaaaaaaaa \\
+    : \\
+        True
 
 `;
 
 exports[`lambdas.py 2`] = `
 key=lambda variable: variable[0]
-max(lis, key=lambda x:int(x))~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+max(lis, key=lambda x:int(x))
+f = lambda param: some_very_long_variable_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+f = lambda some_very_long_param_name_1_aaaaaaaaaa, some_very_long_param_name_2_aaaaaaaaaa, some_very_long_param_name_3_aaaaaaaaaa: True
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 key = lambda variable: variable[0]
 
 max(lis, key=lambda x: int(x))
+
+f = lambda param: \\
+        some_very_long_variable_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+f = lambda \\
+        some_very_long_param_name_1_aaaaaaaaaa, \\
+        some_very_long_param_name_2_aaaaaaaaaa, \\
+        some_very_long_param_name_3_aaaaaaaaaa, \\
+    : \\
+        True
+
+`;
+
+exports[`lambdas.py 3`] = `
+key=lambda variable: variable[0]
+max(lis, key=lambda x:int(x))
+f = lambda param: some_very_long_variable_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+f = lambda some_very_long_param_name_1_aaaaaaaaaa, some_very_long_param_name_2_aaaaaaaaaa, some_very_long_param_name_3_aaaaaaaaaa: True
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+key = lambda variable: variable[0]
+
+max(lis, key=lambda x: int(x))
+
+f = lambda param: \\
+        some_very_long_variable_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+f = lambda \\
+        some_very_long_param_name_1_aaaaaaaaaa, \\
+        some_very_long_param_name_2_aaaaaaaaaa, \\
+        some_very_long_param_name_3_aaaaaaaaaa \\
+    : \\
+        True
 
 `;

--- a/tests/python_lambdas/jsfmt.spec.js
+++ b/tests/python_lambdas/jsfmt.spec.js
@@ -1,2 +1,3 @@
-run_spec(__dirname, ["python"], { pythonVersion: "2" });
+run_spec(__dirname, ["python"], { pythonVersion: "2", trailingComma: "none" });
+run_spec(__dirname, ["python"], { pythonVersion: "2", trailingComma: "all" });
 run_spec(__dirname, ["python"], { pythonVersion: "3" });

--- a/tests/python_lambdas/lambdas.py
+++ b/tests/python_lambdas/lambdas.py
@@ -1,2 +1,4 @@
 key=lambda variable: variable[0]
 max(lis, key=lambda x:int(x))
+f = lambda param: some_very_long_variable_name_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+f = lambda some_very_long_param_name_1_aaaaaaaaaa, some_very_long_param_name_2_aaaaaaaaaa, some_very_long_param_name_3_aaaaaaaaaa: True

--- a/tests/python_long/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_long/__snapshots__/jsfmt.spec.js.snap
@@ -18,6 +18,18 @@ def this_is_a_long_function(this_is_a_long_parameter, this_is_another_long_param
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 def this_is_a_long_function(
     this_is_a_long_parameter,
+    this_is_another_long_parameter,
+):
+    print("hello world", this_is_another_long_parameter)
+
+`;
+
+exports[`hello.py 3`] = `
+def this_is_a_long_function(this_is_a_long_parameter, this_is_another_long_parameter):
+    print("hello world", this_is_another_long_parameter)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+def this_is_a_long_function(
+    this_is_a_long_parameter,
     this_is_another_long_parameter
 ):
     print("hello world", this_is_another_long_parameter)

--- a/tests/python_long/jsfmt.spec.js
+++ b/tests/python_long/jsfmt.spec.js
@@ -1,2 +1,3 @@
-run_spec(__dirname, ["python"], { pythonVersion: "2" });
+run_spec(__dirname, ["python"], { pythonVersion: "2", trailingComma: "none" });
+run_spec(__dirname, ["python"], { pythonVersion: "2", trailingComma: "all" });
 run_spec(__dirname, ["python"], { pythonVersion: "3" });


### PR DESCRIPTION
This diff changes lambdas so that they wrap if they're too long. They will first try just putting the body on a separate line, then if the arguments are still too long they will break each argument onto its own line. Since this adds trailing comma support to arguments lists, I also added a test that function parameters get trailing commas when arguments are wrapped onto separate lines.