### PR TITLE
Don't try to canonicalize strings in multiple parts

### DIFF
--- a/tests/python3_f_strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python3_f_strings/__snapshots__/jsfmt.spec.js.snap
@@ -6,6 +6,18 @@ precision = 4
 value = decimal.Decimal("12.34567")
 f"result: {value:{width}.{precision}}"
 rf"result: {value:{width}.{precision}}"
+
+# These require a fix in the asttoken library to work correctly.
+# See https://github.com/gristlabs/asttokens/pull/13
+#
+# foo(f'this SHOULD be a multi-line string because it is '
+#     f'very long and does not fit on one line. And {value} is the value.')
+#
+# foo('this SHOULD be a multi-line string, but not reflowed because it is '
+#     f'very long and and also unusual. And {value} is the value.')
+#
+# foo(fR"this should NOT be \\t "
+#     rF'a multi-line string \\n')
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 width = 10
 
@@ -16,5 +28,17 @@ value = decimal.Decimal("12.34567")
 f"result: {value:{width}.{precision}}"
 
 rf"result: {value:{width}.{precision}}"
+
+# These require a fix in the asttoken library to work correctly.
+# See https://github.com/gristlabs/asttokens/pull/13
+#
+# foo(f'this SHOULD be a multi-line string because it is '
+#     f'very long and does not fit on one line. And {value} is the value.')
+#
+# foo('this SHOULD be a multi-line string, but not reflowed because it is '
+#     f'very long and and also unusual. And {value} is the value.')
+#
+# foo(fR"this should NOT be \\t "
+#     rF'a multi-line string \\n')
 
 `;

--- a/tests/python3_f_strings/f_strings.py
+++ b/tests/python3_f_strings/f_strings.py
@@ -3,3 +3,15 @@ precision = 4
 value = decimal.Decimal("12.34567")
 f"result: {value:{width}.{precision}}"
 rf"result: {value:{width}.{precision}}"
+
+# These require a fix in the asttoken library to work correctly.
+# See https://github.com/gristlabs/asttokens/pull/13
+#
+# foo(f'this SHOULD be a multi-line string because it is '
+#     f'very long and does not fit on one line. And {value} is the value.')
+#
+# foo('this SHOULD be a multi-line string, but not reflowed because it is '
+#     f'very long and and also unusual. And {value} is the value.')
+#
+# foo(fR"this should NOT be \t "
+#     rF'a multi-line string \n')

--- a/tests/python_strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_strings/__snapshots__/jsfmt.spec.js.snap
@@ -2,11 +2,75 @@
 
 exports[`strings.py 1`] = `
 a = "it is \\"ok\\""
+a = "it is 'ok'"
+a = 'it is \\'ok\\''
+a = 'it is "ok"'
+
 a = """this is a multiline
 string"""
 b = '''another multiline
 string'''
+
+a = "both 'single' and \\"double\\""
+a = 'both \\'single\\' and "double"'
+
+a = u"unicode snowman: \\u26C4"
+a = r"this does not have a tab: \\t"
+# Bytes crash the astexport.py script
+# a = b"here's some bytes"
+
+a = '''escaped triple quote \\''' in middle'''
+a = """escaped triple quote \\""" in middle"""
+
+a = """other triple quote ''' in the middle"""
+a = '''other triple quote """ in the middle'''
+
+# The interior triple quotes don't get escaped properly
+# a = '''both triple quotes """ and \\''' in the middle'''
+# a = """both triple quotes ''' and \\""" in the middle"""
+
+# In the future these might be re-flowed, if that's a feature we want to
+# implement.
+
+foo('this should NOT be '
+    'a multi-line string')
+
+foo("this should NOT be "
+    'a multi-line string')
+
+foo(r"this should NOT be \\t "
+    r'a multi-line string \\n')
+
+# Bytes crash the astexport.py script
+#foo(bR"this should NOT be \\t "
+#    Br'a multi-line string \\n')
+
+foo("""this should remain as is """
+    '''because it is really weird''')
+
+foo("this should remain as is \\t "
+    r'because it is really weird \\n')
+
+foo(
+    'this SHOULD be a multi-line string because it is very long and does not fit on one line'
+)
+
+foo(
+    'this SHOULD be re-flowed, but still a multi-line string '
+    "because it is very long and does not fit on one line"
+)
+
+foo(
+    '''this SHOULD NOT be re-flowed, but still a multi-line string '''
+    """because it is very long and does not fit on one line"""
+)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+a = 'it is "ok"'
+
+a = "it is 'ok'"
+
+a = "it is 'ok'"
+
 a = 'it is "ok"'
 
 a = """this is a multiline
@@ -14,16 +78,119 @@ string"""
 
 b = """another multiline
 string"""
+
+a = "both 'single' and \\"double\\""
+
+a = "both 'single' and \\"double\\""
+
+a = u"unicode snowman: \\u26C4"
+
+a = r"this does not have a tab: \\t"
+
+a = """escaped triple quote \\''' in middle"""
+
+a = '''escaped triple quote """ in middle'''
+
+a = """other triple quote ''' in the middle"""
+
+a = '''other triple quote """ in the middle'''
+
+foo('this should NOT be '
+    'a multi-line string')
+
+foo("this should NOT be "
+    'a multi-line string')
+
+foo(r"this should NOT be \\t "
+    r'a multi-line string \\n')
+
+foo("""this should remain as is """
+    '''because it is really weird''')
+
+foo("this should remain as is \\t "
+    r'because it is really weird \\n')
+
+foo("this SHOULD be a multi-line string because it is very long and does not fit on one line")
+
+foo('this SHOULD be re-flowed, but still a multi-line string '
+    "because it is very long and does not fit on one line")
+
+foo('''this SHOULD NOT be re-flowed, but still a multi-line string '''
+    """because it is very long and does not fit on one line""")
 
 `;
 
 exports[`strings.py 2`] = `
 a = "it is \\"ok\\""
+a = "it is 'ok'"
+a = 'it is \\'ok\\''
+a = 'it is "ok"'
+
 a = """this is a multiline
 string"""
 b = '''another multiline
 string'''
+
+a = "both 'single' and \\"double\\""
+a = 'both \\'single\\' and "double"'
+
+a = u"unicode snowman: \\u26C4"
+a = r"this does not have a tab: \\t"
+# Bytes crash the astexport.py script
+# a = b"here's some bytes"
+
+a = '''escaped triple quote \\''' in middle'''
+a = """escaped triple quote \\""" in middle"""
+
+a = """other triple quote ''' in the middle"""
+a = '''other triple quote """ in the middle'''
+
+# The interior triple quotes don't get escaped properly
+# a = '''both triple quotes """ and \\''' in the middle'''
+# a = """both triple quotes ''' and \\""" in the middle"""
+
+# In the future these might be re-flowed, if that's a feature we want to
+# implement.
+
+foo('this should NOT be '
+    'a multi-line string')
+
+foo("this should NOT be "
+    'a multi-line string')
+
+foo(r"this should NOT be \\t "
+    r'a multi-line string \\n')
+
+# Bytes crash the astexport.py script
+#foo(bR"this should NOT be \\t "
+#    Br'a multi-line string \\n')
+
+foo("""this should remain as is """
+    '''because it is really weird''')
+
+foo("this should remain as is \\t "
+    r'because it is really weird \\n')
+
+foo(
+    'this SHOULD be a multi-line string because it is very long and does not fit on one line'
+)
+
+foo(
+    'this SHOULD be re-flowed, but still a multi-line string '
+    "because it is very long and does not fit on one line"
+)
+
+foo(
+    '''this SHOULD NOT be re-flowed, but still a multi-line string '''
+    """because it is very long and does not fit on one line"""
+)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+a = 'it is "ok"'
+
+a = "it is 'ok'"
+
+a = "it is 'ok'"
+
 a = 'it is "ok"'
 
 a = """this is a multiline
@@ -31,5 +198,58 @@ string"""
 
 b = """another multiline
 string"""
+
+a = "both 'single' and \\"double\\""
+
+a = "both 'single' and \\"double\\""
+
+a = u"unicode snowman: \\u26C4"
+
+a = r"this does not have a tab: \\t"
+
+# Bytes crash the astexport.py script
+# a = b"here's some bytes"
+
+a = """escaped triple quote \\''' in middle"""
+
+a = '''escaped triple quote """ in middle'''
+
+a = """other triple quote ''' in the middle"""
+
+a = '''other triple quote """ in the middle'''
+
+# The interior triple quotes don't get escaped properly
+# a = '''both triple quotes """ and \\''' in the middle'''
+# a = """both triple quotes ''' and \\""" in the middle"""
+
+# In the future these might be re-flowed, if that's a feature we want to
+# implement.
+
+foo('this should NOT be '
+    'a multi-line string')
+
+foo("this should NOT be "
+    'a multi-line string')
+
+foo(r"this should NOT be \\t "
+    r'a multi-line string \\n')
+
+# Bytes crash the astexport.py script
+#foo(bR"this should NOT be \\t "
+#    Br'a multi-line string \\n')
+
+foo("""this should remain as is """
+    '''because it is really weird''')
+
+foo("this should remain as is \\t "
+    r'because it is really weird \\n')
+
+foo("this SHOULD be a multi-line string because it is very long and does not fit on one line")
+
+foo('this SHOULD be re-flowed, but still a multi-line string '
+    "because it is very long and does not fit on one line")
+
+foo('''this SHOULD NOT be re-flowed, but still a multi-line string '''
+    """because it is very long and does not fit on one line""")
 
 `;

--- a/tests/python_strings/strings.py
+++ b/tests/python_strings/strings.py
@@ -1,5 +1,63 @@
 a = "it is \"ok\""
+a = "it is 'ok'"
+a = 'it is \'ok\''
+a = 'it is "ok"'
+
 a = """this is a multiline
 string"""
 b = '''another multiline
 string'''
+
+a = "both 'single' and \"double\""
+a = 'both \'single\' and "double"'
+
+a = u"unicode snowman: \u26C4"
+a = r"this does not have a tab: \t"
+# Bytes crash the astexport.py script
+# a = b"here's some bytes"
+
+a = '''escaped triple quote \''' in middle'''
+a = """escaped triple quote \""" in middle"""
+
+a = """other triple quote ''' in the middle"""
+a = '''other triple quote """ in the middle'''
+
+# The interior triple quotes don't get escaped properly
+# a = '''both triple quotes """ and \''' in the middle'''
+# a = """both triple quotes ''' and \""" in the middle"""
+
+# In the future these might be re-flowed, if that's a feature we want to
+# implement.
+
+foo('this should NOT be '
+    'a multi-line string')
+
+foo("this should NOT be "
+    'a multi-line string')
+
+foo(r"this should NOT be \t "
+    r'a multi-line string \n')
+
+# Bytes crash the astexport.py script
+#foo(bR"this should NOT be \t "
+#    Br'a multi-line string \n')
+
+foo("""this should remain as is """
+    '''because it is really weird''')
+
+foo("this should remain as is \t "
+    r'because it is really weird \n')
+
+foo(
+    'this SHOULD be a multi-line string because it is very long and does not fit on one line'
+)
+
+foo(
+    'this SHOULD be re-flowed, but still a multi-line string '
+    "because it is very long and does not fit on one line"
+)
+
+foo(
+    '''this SHOULD NOT be re-flowed, but still a multi-line string '''
+    """because it is very long and does not fit on one line"""
+)


### PR DESCRIPTION
We currently try to canonicalize strings to use consistent quotes. However, there are a number of cases where this breaks and produces invalid Python code. As a short term stop-gap, this diff tries to detect those scenarios and bail early, leaving the string as-is.

This diff adds a number of tests which expose this behavior. Some of the tests are set up to maybe one day check more advanced behavior (like automatically re-flowing strings) but for now they just test the fixes here. There are also a few new tests commented out because we still don't handle them properly, and either crash or produce invalid Python. This also adds some comments for similar tests we could add for f-strings, but those require a fix in the ASTTokens library to work correctly.