### PR TITLE
Fix open slices and improve slice wrapping

### DIFF
--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -607,10 +607,11 @@ function genericPrint(path, options, print) {
     }
 
     case "Subscript": {
-      return concat([
+      return groupConcat([
         path.call(print, "value"),
         "[",
-        path.call(print, "slice"),
+        indentConcat([softline, path.call(print, "slice")]),
+        softline,
         "]"
       ]);
     }
@@ -620,21 +621,16 @@ function genericPrint(path, options, print) {
     }
 
     case "Slice": {
-      const parts = [path.call(print, "lower")];
+      const stepParts = n.step ? [":", softline, path.call(print, "step")] : [];
 
-      if (n.upper) {
-        parts.push(path.call(print, "upper"));
-      }
-
-      if (n.step) {
-        if (!n.upper) {
-          parts.push("");
-        }
-
-        parts.push(path.call(print, "step"));
-      }
-
-      return join(":", parts);
+      return groupConcat(
+        [
+          path.call(print, "lower"),
+          ":",
+          softline,
+          path.call(print, "upper")
+        ].concat(stepParts)
+      );
     }
 
     case "UnaryOp": {

--- a/tests/python_subscript/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_subscript/__snapshots__/jsfmt.spec.js.snap
@@ -10,6 +10,14 @@ a[-1]
 a[0:-1:2]
 a[1][0]
 a[::-1]
+a[1:]
+a[:1]
+a[:]
+
+long_list_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[lower_bound:upper_bound:step]
+long_list_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+    long_lower_bound_aaaaaaaaaaa:long_upper_bound_aaaaaaaaaaa:long_step_aaaaaaaaaaa
+]
 
 c = {'a': 3}
 
@@ -30,6 +38,22 @@ a[0:-1:2]
 a[1][0]
 
 a[::-1]
+
+a[1:]
+
+a[:1]
+
+a[:]
+
+long_list_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+    lower_bound:upper_bound:step
+]
+
+long_list_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+    long_lower_bound_aaaaaaaaaaa:
+    long_upper_bound_aaaaaaaaaaa:
+    long_step_aaaaaaaaaaa
+]
 
 c = {"a": 3}
 
@@ -47,6 +71,14 @@ a[-1]
 a[0:-1:2]
 a[1][0]
 a[::-1]
+a[1:]
+a[:1]
+a[:]
+
+long_list_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[lower_bound:upper_bound:step]
+long_list_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+    long_lower_bound_aaaaaaaaaaa:long_upper_bound_aaaaaaaaaaa:long_step_aaaaaaaaaaa
+]
 
 c = {'a': 3}
 
@@ -67,6 +99,22 @@ a[0:-1:2]
 a[1][0]
 
 a[::-1]
+
+a[1:]
+
+a[:1]
+
+a[:]
+
+long_list_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+    lower_bound:upper_bound:step
+]
+
+long_list_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+    long_lower_bound_aaaaaaaaaaa:
+    long_upper_bound_aaaaaaaaaaa:
+    long_step_aaaaaaaaaaa
+]
 
 c = {"a": 3}
 

--- a/tests/python_subscript/subscript.py
+++ b/tests/python_subscript/subscript.py
@@ -7,6 +7,14 @@ a[-1]
 a[0:-1:2]
 a[1][0]
 a[::-1]
+a[1:]
+a[:1]
+a[:]
+
+long_list_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[lower_bound:upper_bound:step]
+long_list_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa[
+    long_lower_bound_aaaaaaaaaaa:long_upper_bound_aaaaaaaaaaa:long_step_aaaaaaaaaaa
+]
 
 c = {'a': 3}
 


### PR DESCRIPTION
There was a bug where slices that were open at the end (eg `foo[1:]`) would be rendered without the `:` character. This adds tests for open slices and fixes the implementation to always include the `:`. It also adds tests for wrapping long slices, and the corresponding implementation.