### PR TITLE
Handle unary not operator

### DIFF
--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -638,7 +638,10 @@ function genericPrint(path, options, print) {
     }
 
     case "UnaryOp": {
-      const separator = n.op.ast_type === "Not" ? line : "";
+      // We don't use a line or escapedLine with Not because wrapping and
+      // indenting doesn't make sense with a 4-space indent, since the operand
+      // will be starting at the same column anyway.
+      const separator = n.op.ast_type === "Not" ? " " : "";
 
       return groupConcat([
         path.call(print, "op"),

--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -638,7 +638,13 @@ function genericPrint(path, options, print) {
     }
 
     case "UnaryOp": {
-      return concat([path.call(print, "op"), path.call(print, "operand")]);
+      const separator = n.op.ast_type === "Not" ? line : "";
+
+      return groupConcat([
+        path.call(print, "op"),
+        separator,
+        path.call(print, "operand")
+      ]);
     }
 
     case "ListComp": {

--- a/tests/python_expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_expressions/__snapshots__/jsfmt.spec.js.snap
@@ -119,6 +119,8 @@ a is not b
 a in b
 a is b
 not a
+# We don't wrap this because it doesn't make sense with a 4-space indent.
+not my_long_variable_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 3 < x < 5
 # (3 < x) < 5
 a < b < c < d
@@ -492,6 +494,8 @@ a in b
 a is b
 
 not a
+
+not my_long_variable_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 3 < x < 5
 
@@ -827,6 +831,8 @@ a is not b
 a in b
 a is b
 not a
+# We don't wrap this because it doesn't make sense with a 4-space indent.
+not my_long_variable_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 3 < x < 5
 # (3 < x) < 5
 a < b < c < d
@@ -1234,6 +1240,9 @@ a in b
 a is b
 
 not a
+
+# We don't wrap this because it doesn't make sense with a 4-space indent.
+not my_long_variable_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 3 < x < 5
 

--- a/tests/python_expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_expressions/__snapshots__/jsfmt.spec.js.snap
@@ -118,6 +118,7 @@ a not in b
 a is not b
 a in b
 a is b
+not a
 3 < x < 5
 # (3 < x) < 5
 a < b < c < d
@@ -489,6 +490,8 @@ a is not b
 a in b
 
 a is b
+
+not a
 
 3 < x < 5
 
@@ -823,6 +826,7 @@ a not in b
 a is not b
 a in b
 a is b
+not a
 3 < x < 5
 # (3 < x) < 5
 a < b < c < d
@@ -1228,6 +1232,8 @@ a is not b
 a in b
 
 a is b
+
+not a
 
 3 < x < 5
 

--- a/tests/python_expressions/expressions.py
+++ b/tests/python_expressions/expressions.py
@@ -115,6 +115,7 @@ a not in b
 a is not b
 a in b
 a is b
+not a
 3 < x < 5
 # (3 < x) < 5
 a < b < c < d

--- a/tests/python_expressions/expressions.py
+++ b/tests/python_expressions/expressions.py
@@ -116,6 +116,8 @@ a is not b
 a in b
 a is b
 not a
+# We don't wrap this because it doesn't make sense with a 4-space indent.
+not my_long_variable_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 3 < x < 5
 # (3 < x) < 5
 a < b < c < d


### PR DESCRIPTION
Unlike the other unary operators, `not` needs a space after it. This adds a test for the expected behavior and then implements that behavior.