### PR TITLE
Handle generator expressions

### DIFF
--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -672,6 +672,26 @@ function genericPrint(path, options, print) {
       );
     }
 
+    case "GeneratorExp": {
+      // If this is the only argument to a function, we can skip the parens
+      // around it.
+      const parent = path.getParentNode();
+      const skipParens =
+        parent.ast_type === "Call" &&
+        parent.args.length === 1 &&
+        parent.args[0] === n;
+
+      const open = skipParens ? "" : "(";
+      const close = skipParens ? "" : ")";
+
+      return printComprehensionLike(
+        open,
+        path.call(print, "elt"),
+        path.map(print, "generators"),
+        close
+      );
+    }
+
     case "comprehension": {
       const parts = [printForIn(path, print)];
 

--- a/tests/python_generator_expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_generator_expressions/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generator_expressions.py 1`] = `
+(x for x in range(100))
+(x for x in range(100) if x % 2 == 0)
+
+my_long_variable_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = (thing for thing in things)
+
+a = (my_long_function_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing) for thing in things)
+
+a = (my_long_function_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing) for thing in things if thing is not None)
+
+a = (my_long_function_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing) for thing in things if my_long_predicate_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing))
+
+list(x for x in bar)
+
+foo((x for x in bar), True)
+
+foo(True, (x for x in bar))
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+(x for x in range(100))
+
+(x for x in range(100) if x % 2 == 0)
+
+my_long_variable_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = (
+    thing for thing in things
+)
+
+a = (
+    my_long_function_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing)
+    for thing in things
+)
+
+a = (
+    my_long_function_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing)
+    for thing in things if thing is not None
+)
+
+a = (
+    my_long_function_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing)
+    for thing in things
+    if my_long_predicate_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing)
+)
+
+list(x for x in bar)
+
+foo((x for x in bar), True)
+
+foo(True, (x for x in bar))
+
+`;
+
+exports[`generator_expressions.py 2`] = `
+(x for x in range(100))
+(x for x in range(100) if x % 2 == 0)
+
+my_long_variable_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = (thing for thing in things)
+
+a = (my_long_function_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing) for thing in things)
+
+a = (my_long_function_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing) for thing in things if thing is not None)
+
+a = (my_long_function_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing) for thing in things if my_long_predicate_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing))
+
+list(x for x in bar)
+
+foo((x for x in bar), True)
+
+foo(True, (x for x in bar))
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+(x for x in range(100))
+
+(x for x in range(100) if x % 2 == 0)
+
+my_long_variable_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = (
+    thing for thing in things
+)
+
+a = (
+    my_long_function_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing)
+    for thing in things
+)
+
+a = (
+    my_long_function_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing)
+    for thing in things if thing is not None
+)
+
+a = (
+    my_long_function_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing)
+    for thing in things
+    if my_long_predicate_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing)
+)
+
+list(x for x in bar)
+
+foo((x for x in bar), True)
+
+foo(True, (x for x in bar))
+
+`;

--- a/tests/python_generator_expressions/generator_expressions.py
+++ b/tests/python_generator_expressions/generator_expressions.py
@@ -1,0 +1,16 @@
+(x for x in range(100))
+(x for x in range(100) if x % 2 == 0)
+
+my_long_variable_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = (thing for thing in things)
+
+a = (my_long_function_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing) for thing in things)
+
+a = (my_long_function_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing) for thing in things if thing is not None)
+
+a = (my_long_function_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing) for thing in things if my_long_predicate_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa(thing))
+
+list(x for x in bar)
+
+foo((x for x in bar), True)
+
+foo(True, (x for x in bar))

--- a/tests/python_generator_expressions/jsfmt.spec.js
+++ b/tests/python_generator_expressions/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname, ["python"], { pythonVersion: "2" });
+run_spec(__dirname, ["python"], { pythonVersion: "3" });


### PR DESCRIPTION
Add logic to print out generator expressions, including eliding the parentheses when the expression is the only argument to a function call.