### PR TITLE
Handle Python 3 type annotations

### DIFF
--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -138,17 +138,27 @@ function printArguments(print, path, argsKey, defaultsKey) {
     const next = merge[i + 1];
 
     const part = [path.call(print, argsKey, currentArgument)];
+    const argNode = path.call(path => path.getNode(), argsKey, currentArgument);
 
     currentArgument += 1;
 
     if (next && next.isDefault) {
-      part.push("=", path.call(print, defaultsKey, currentDefault));
+      const equal = argNode.annotation ? " =" : "=";
+      const appropriateLine = argNode.annotation ? line : softline;
+
+      part.push(
+        equal,
+        indentConcat([
+          appropriateLine,
+          path.call(print, defaultsKey, currentDefault)
+        ])
+      );
 
       i += 1;
       currentDefault += 1;
     }
 
-    parts.push(concat(part));
+    parts.push(groupConcat(part));
   }
 
   return parts;
@@ -352,10 +362,14 @@ function genericPrint(path, options, print) {
           indentConcat([softline, path.call(print, "args")]),
           softline,
           ")"
-        ]),
-        ":",
-        indentConcat([hardline, printBody(path, print)])
+        ])
       );
+
+      if (n.returns) {
+        parts.push(" -> ", path.call(print, "returns"));
+      }
+
+      parts.push(":", indentConcat([hardline, printBody(path, print)]));
 
       return concat(parts);
     }
@@ -397,7 +411,10 @@ function genericPrint(path, options, print) {
     }
 
     case "arg": {
-      return n.arg;
+      const annotationParts = n.annotation
+        ? [":", indentConcat([line, path.call(print, "annotation")])]
+        : [];
+      return groupConcat([n.arg].concat(annotationParts));
     }
 
     case "Expr": {
@@ -507,6 +524,18 @@ function genericPrint(path, options, print) {
         "= ",
         path.call(print, "value")
       ]);
+    }
+
+    case "AnnAssign": {
+      const valueParts = n.value ? [" = ", path.call(print, "value")] : [];
+
+      return groupConcat(
+        [
+          path.call(print, "target"),
+          ":",
+          indentConcat([escapedLine, path.call(print, "annotation")])
+        ].concat(valueParts)
+      );
     }
 
     case "Dict": {
@@ -856,6 +885,10 @@ function genericPrint(path, options, print) {
 
     case "Set": {
       return printListLike("{", path.map(print, "elts"), trailingComma, "}");
+    }
+
+    case "Ellipsis": {
+      return "...";
     }
 
     /* istanbul ignore next */

--- a/tests/python_ann_assign/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_ann_assign/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ann_assign.py 1`] = `
+a: str
+a: bool = True
+
+my_long_var_aaaaaaaaaaaaaaaaaaaaaaaaaa: MyLongTypeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+my_long_var_aaaaaaaaaaaaaaaaaaaaaaaaaa: MyLongTypeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA = 1
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+a: str
+
+a: bool = True
+
+my_long_var_aaaaaaaaaaaaaaaaaaaaaaaaaa: \\
+    MyLongTypeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+my_long_var_aaaaaaaaaaaaaaaaaaaaaaaaaa: \\
+    MyLongTypeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA = 1
+
+`;

--- a/tests/python_ann_assign/ann_assign.py
+++ b/tests/python_ann_assign/ann_assign.py
@@ -1,0 +1,6 @@
+a: str
+a: bool = True
+
+my_long_var_aaaaaaaaaaaaaaaaaaaaaaaaaa: MyLongTypeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+
+my_long_var_aaaaaaaaaaaaaaaaaaaaaaaaaa: MyLongTypeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA = 1

--- a/tests/python_ann_assign/jsfmt.spec.js
+++ b/tests/python_ann_assign/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["python"], { pythonVersion: "3" });

--- a/tests/python_arg_annotations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_arg_annotations/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`args_annotations.py 1`] = `
+class MyThing:
+    pass
+
+def hello(a: int, b: str, c: Optional[MyThing]) -> None:
+    pass
+
+
+def long_annotation(my_long_variable_name_aaaaaaaaaaaaaaaaaaa: MyLongTypeNameAAAAAAAAAAAAAAAAAAAAA) -> None:
+    pass
+
+
+def ellipses(arg:Tuple[str,...])->Optional[Tuple[str,...]]:
+    return None
+
+
+def default_args(verbose: bool=False):
+    pass
+
+
+def annotation_with_long_default(
+    my_long_variable_name_aaaaaaaaaaaaaaaaaaa: MyTypeName = my_long_default_value_aa
+):
+    pass
+
+
+def long_annotation_with_long_default(
+    my_long_variable_name_aaaaaaaaaaaaaaaaaaa:
+        MyLongTypeNameAAAAAAAAAAAAAAAAAAAAA = my_long_default_value_aaaaaaaaaaaaaa
+):
+    pass
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class MyThing:
+    pass
+
+def hello(a: int, b: str, c: Optional[MyThing]) -> None:
+    pass
+
+def long_annotation(
+    my_long_variable_name_aaaaaaaaaaaaaaaaaaa:
+        MyLongTypeNameAAAAAAAAAAAAAAAAAAAAA
+) -> None:
+    pass
+
+def ellipses(arg: Tuple[str, ...]) -> Optional[Tuple[str, ...]]:
+    return None
+
+def default_args(verbose: bool = False):
+    pass
+
+def annotation_with_long_default(
+    my_long_variable_name_aaaaaaaaaaaaaaaaaaa: MyTypeName =
+        my_long_default_value_aa
+):
+    pass
+
+def long_annotation_with_long_default(
+    my_long_variable_name_aaaaaaaaaaaaaaaaaaa:
+        MyLongTypeNameAAAAAAAAAAAAAAAAAAAAA =
+        my_long_default_value_aaaaaaaaaaaaaa
+):
+    pass
+
+`;

--- a/tests/python_arg_annotations/args_annotations.py
+++ b/tests/python_arg_annotations/args_annotations.py
@@ -1,0 +1,30 @@
+class MyThing:
+    pass
+
+def hello(a: int, b: str, c: Optional[MyThing]) -> None:
+    pass
+
+
+def long_annotation(my_long_variable_name_aaaaaaaaaaaaaaaaaaa: MyLongTypeNameAAAAAAAAAAAAAAAAAAAAA) -> None:
+    pass
+
+
+def ellipses(arg:Tuple[str,...])->Optional[Tuple[str,...]]:
+    return None
+
+
+def default_args(verbose: bool=False):
+    pass
+
+
+def annotation_with_long_default(
+    my_long_variable_name_aaaaaaaaaaaaaaaaaaa: MyTypeName = my_long_default_value_aa
+):
+    pass
+
+
+def long_annotation_with_long_default(
+    my_long_variable_name_aaaaaaaaaaaaaaaaaaa:
+        MyLongTypeNameAAAAAAAAAAAAAAAAAAAAA = my_long_default_value_aaaaaaaaaaaaaa
+):
+    pass

--- a/tests/python_arg_annotations/jsfmt.spec.js
+++ b/tests/python_arg_annotations/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["python"], { pythonVersion: "3" });


### PR DESCRIPTION
Add tests and functionality that Python 3 type annotations on function arguments, function return types, and locals are preserved and wrapped properly if too long.