### PR TITLE
Update in-repo copy of asttokens

### DIFF
--- a/vendor/python/asttokens/asttokens.py
+++ b/vendor/python/asttokens/asttokens.py
@@ -153,12 +153,13 @@ class ASTTokens(object):
   def find_token(self, start_token, tok_type, tok_str=None, reverse=False):
     """
     Looks for the first token, starting at start_token, that matches tok_type and, if given, the
-    token string. Searches backwards if reverse is True.
+    token string. Searches backwards if reverse is True. Returns ENDMARKER token if not found (you
+    can check it with `token.ISEOF(t.type)`.
     """
     t = start_token
     advance = self.prev_token if reverse else self.next_token
     while not match_token(t, tok_type, tok_str) and not token.ISEOF(t.type):
-      t = advance(t)
+      t = advance(t, include_extra=True)
     return t
 
   def token_range(self, first_token, last_token, include_extra=False):

--- a/vendor/python/asttokens/mark_tokens.py
+++ b/vendor/python/asttokens/mark_tokens.py
@@ -230,6 +230,12 @@ class MarkTokens(object):
     return (first_token, last_token)
 
   def visit_str(self, node, first_token, last_token):
+    return self.handle_str(first_token, last_token)
+
+  def visit_joinedstr(self, node, first_token, last_token):
+    return self.handle_str(first_token, last_token)
+
+  def handle_str(self, first_token, last_token):
     # Multiple adjacent STRING tokens form a single string.
     last = self._code.next_token(last_token)
     while util.match_token(last, token.STRING):
@@ -273,3 +279,9 @@ class MarkTokens(object):
       colon = self._code.find_token(last_token, token.OP, ':')
       first_token = last_token = self._code.prev_token(colon)
     return (first_token, last_token)
+
+  if six.PY2:
+    # No need for this on Python3, which already handles 'with' nodes correctly.
+    def visit_with(self, node, first_token, last_token):
+      first = self._code.find_token(first_token, token.NAME, 'with', reverse=True)
+      return (first, last_token)


### PR DESCRIPTION
This updates the code to https://github.com/gristlabs/asttokens/commit/3518f5ae323f5a390f8894557db8285eb1ec7e34. In the future we might want to look into using a virtualenv or something like that so we don't need to keep our own copy of this code, but this isn't any worse than the existing situation.