### PR TITLE
Uncomment f-strings test after updating asttokens

### DIFF
--- a/tests/python3_f_strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python3_f_strings/__snapshots__/jsfmt.spec.js.snap
@@ -7,17 +7,14 @@ value = decimal.Decimal("12.34567")
 f"result: {value:{width}.{precision}}"
 rf"result: {value:{width}.{precision}}"
 
-# These require a fix in the asttoken library to work correctly.
-# See https://github.com/gristlabs/asttokens/pull/13
-#
-# foo(f'this SHOULD be a multi-line string because it is '
-#     f'very long and does not fit on one line. And {value} is the value.')
-#
-# foo('this SHOULD be a multi-line string, but not reflowed because it is '
-#     f'very long and and also unusual. And {value} is the value.')
-#
-# foo(fR"this should NOT be \\t "
-#     rF'a multi-line string \\n')
+foo(f'this SHOULD be a multi-line string because it is '
+    f'very long and does not fit on one line. And {value} is the value.')
+
+foo('this SHOULD be a multi-line string, but not reflowed because it is '
+    f'very long and and also unusual. And {value} is the value.')
+
+foo(fR"this should NOT be \\t "
+    rF'a multi-line string \\n')
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 width = 10
 precision = 4
@@ -25,16 +22,13 @@ value = decimal.Decimal("12.34567")
 f"result: {value:{width}.{precision}}"
 rf"result: {value:{width}.{precision}}"
 
-# These require a fix in the asttoken library to work correctly.
-# See https://github.com/gristlabs/asttokens/pull/13
-#
-# foo(f'this SHOULD be a multi-line string because it is '
-#     f'very long and does not fit on one line. And {value} is the value.')
-#
-# foo('this SHOULD be a multi-line string, but not reflowed because it is '
-#     f'very long and and also unusual. And {value} is the value.')
-#
-# foo(fR"this should NOT be \\t "
-#     rF'a multi-line string \\n')
+foo(f'this SHOULD be a multi-line string because it is '
+    f'very long and does not fit on one line. And {value} is the value.')
+
+foo('this SHOULD be a multi-line string, but not reflowed because it is '
+    f'very long and and also unusual. And {value} is the value.')
+
+foo(fR"this should NOT be \\t "
+    rF'a multi-line string \\n')
 
 `;

--- a/tests/python3_f_strings/f_strings.py
+++ b/tests/python3_f_strings/f_strings.py
@@ -4,14 +4,11 @@ value = decimal.Decimal("12.34567")
 f"result: {value:{width}.{precision}}"
 rf"result: {value:{width}.{precision}}"
 
-# These require a fix in the asttoken library to work correctly.
-# See https://github.com/gristlabs/asttokens/pull/13
-#
-# foo(f'this SHOULD be a multi-line string because it is '
-#     f'very long and does not fit on one line. And {value} is the value.')
-#
-# foo('this SHOULD be a multi-line string, but not reflowed because it is '
-#     f'very long and and also unusual. And {value} is the value.')
-#
-# foo(fR"this should NOT be \t "
-#     rF'a multi-line string \n')
+foo(f'this SHOULD be a multi-line string because it is '
+    f'very long and does not fit on one line. And {value} is the value.')
+
+foo('this SHOULD be a multi-line string, but not reflowed because it is '
+    f'very long and and also unusual. And {value} is the value.')
+
+foo(fR"this should NOT be \t "
+    rF'a multi-line string \n')


### PR DESCRIPTION
The PR that fixed how the asttokens library represents f-strings (technically JoinedStr nodes) was merged in and we updated to that version, so this test now passes.