### PR TITLE
Import formatting

### DIFF
--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -731,7 +731,13 @@ function genericPrint(path, options, print) {
     }
 
     case "Import": {
-      return concat(["import ", join(", ", path.map(print, "names"))]);
+      return groupConcat([
+        "import",
+        indentConcat([
+          escapedLine,
+          group(join(concat([",", escapedLine]), path.map(print, "names")))
+        ])
+      ]);
     }
 
     case "ImportFrom": {
@@ -740,7 +746,12 @@ function genericPrint(path, options, print) {
         ".".repeat(n.level),
         n.module,
         " import ",
-        join(", ", path.map(print, "names"))
+        printListLike(
+          ifBreak("("),
+          path.map(print, "names"),
+          trailingComma,
+          ifBreak(")")
+        )
       ]);
     }
 

--- a/tests/python_import/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_import/__snapshots__/jsfmt.spec.js.snap
@@ -12,6 +12,17 @@ from .models import B as C
 from .example import *
 
 from ..example import *
+
+import long_module_name_1, long_module_name_2, long_module_name_3, long_module_name_4
+
+from some_module import long_function_name_1, long_function_name_2, long_function_name_3
+
+import \\
+    some_module
+
+from some_module import (
+    some_module,
+)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import sys
 
@@ -24,6 +35,22 @@ from .models import B as C
 from .example import *
 
 from ..example import *
+
+import \\
+    long_module_name_1, \\
+    long_module_name_2, \\
+    long_module_name_3, \\
+    long_module_name_4
+
+from some_module import (
+    long_function_name_1,
+    long_function_name_2,
+    long_function_name_3
+)
+
+import some_module
+
+from some_module import some_module
 
 `;
 
@@ -39,6 +66,17 @@ from .models import B as C
 from .example import *
 
 from ..example import *
+
+import long_module_name_1, long_module_name_2, long_module_name_3, long_module_name_4
+
+from some_module import long_function_name_1, long_function_name_2, long_function_name_3
+
+import \\
+    some_module
+
+from some_module import (
+    some_module,
+)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import sys
 
@@ -51,5 +89,75 @@ from .models import B as C
 from .example import *
 
 from ..example import *
+
+import \\
+    long_module_name_1, \\
+    long_module_name_2, \\
+    long_module_name_3, \\
+    long_module_name_4
+
+from some_module import (
+    long_function_name_1,
+    long_function_name_2,
+    long_function_name_3,
+)
+
+import some_module
+
+from some_module import some_module
+
+`;
+
+exports[`import.py 3`] = `
+import sys
+
+from models import X
+
+from .models import X
+
+from .models import B as C
+
+from .example import *
+
+from ..example import *
+
+import long_module_name_1, long_module_name_2, long_module_name_3, long_module_name_4
+
+from some_module import long_function_name_1, long_function_name_2, long_function_name_3
+
+import \\
+    some_module
+
+from some_module import (
+    some_module,
+)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import sys
+
+from models import X
+
+from .models import X
+
+from .models import B as C
+
+from .example import *
+
+from ..example import *
+
+import \\
+    long_module_name_1, \\
+    long_module_name_2, \\
+    long_module_name_3, \\
+    long_module_name_4
+
+from some_module import (
+    long_function_name_1,
+    long_function_name_2,
+    long_function_name_3
+)
+
+import some_module
+
+from some_module import some_module
 
 `;

--- a/tests/python_import/import.py
+++ b/tests/python_import/import.py
@@ -9,3 +9,14 @@ from .models import B as C
 from .example import *
 
 from ..example import *
+
+import long_module_name_1, long_module_name_2, long_module_name_3, long_module_name_4
+
+from some_module import long_function_name_1, long_function_name_2, long_function_name_3
+
+import \
+    some_module
+
+from some_module import (
+    some_module,
+)

--- a/tests/python_import/jsfmt.spec.js
+++ b/tests/python_import/jsfmt.spec.js
@@ -1,2 +1,3 @@
-run_spec(__dirname, ["python"], { pythonVersion: "2" });
+run_spec(__dirname, ["python"], { pythonVersion: "2", trailingComma: "none" });
+run_spec(__dirname, ["python"], { pythonVersion: "2", trailingComma: "all" });
 run_spec(__dirname, ["python"], { pythonVersion: "3" });


### PR DESCRIPTION
Wrap long `import` statements so each module/package is on its own line. Break up the names of `from ... import ...` statements when there are too many to fit on a single line, with a trailing comma if the option is set.