### PR TITLE
Fix 'Value null is not a valid document' in case of a module less import from

### DIFF
--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -744,7 +744,7 @@ function genericPrint(path, options, print) {
       return concat([
         "from ",
         ".".repeat(n.level),
-        n.module,
+        n.module || "",
         " import ",
         printListLike(
           ifBreak("("),

--- a/tests/python_import/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_import/__snapshots__/jsfmt.spec.js.snap
@@ -13,6 +13,8 @@ from .example import *
 
 from ..example import *
 
+from .. import X
+
 import long_module_name_1, long_module_name_2, long_module_name_3, long_module_name_4
 
 from some_module import long_function_name_1, long_function_name_2, long_function_name_3
@@ -35,6 +37,8 @@ from .models import B as C
 from .example import *
 
 from ..example import *
+
+from .. import X
 
 import \\
     long_module_name_1, \\
@@ -67,6 +71,8 @@ from .example import *
 
 from ..example import *
 
+from .. import X
+
 import long_module_name_1, long_module_name_2, long_module_name_3, long_module_name_4
 
 from some_module import long_function_name_1, long_function_name_2, long_function_name_3
@@ -89,6 +95,8 @@ from .models import B as C
 from .example import *
 
 from ..example import *
+
+from .. import X
 
 import \\
     long_module_name_1, \\
@@ -121,6 +129,8 @@ from .example import *
 
 from ..example import *
 
+from .. import X
+
 import long_module_name_1, long_module_name_2, long_module_name_3, long_module_name_4
 
 from some_module import long_function_name_1, long_function_name_2, long_function_name_3
@@ -143,6 +153,8 @@ from .models import B as C
 from .example import *
 
 from ..example import *
+
+from .. import X
 
 import \\
     long_module_name_1, \\

--- a/tests/python_import/import.py
+++ b/tests/python_import/import.py
@@ -10,6 +10,8 @@ from .example import *
 
 from ..example import *
 
+from .. import X
+
 import long_module_name_1, long_module_name_2, long_module_name_3, long_module_name_4
 
 from some_module import long_function_name_1, long_function_name_2, long_function_name_3


### PR DESCRIPTION
This line was making prettier crash:
```python
from .. import X
```
the module is null in this case and concat does not like it.