### PR TITLE
Don't assume python 2 is the default. 

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -22,7 +22,7 @@ function parseText(text, pythonExecutable) {
 }
 
 function parse(text, parsers, opts) {
-  const pythonExectuable = `python${opts.pythonVersion == "2" ? "" : "3"}`;
+  const pythonExectuable = `python${opts.pythonVersion}`;
   const executionResult = parseText(text, pythonExectuable);
 
   const res = executionResult.stdout.toString();


### PR DESCRIPTION
Use explicit `python2` and `python3` executables.
`python2` link seems to be present on most arch.
Closes #47 