### PR TITLE
Space `with` arguments

### DIFF
--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -986,7 +986,7 @@ function genericPrint(path, options, print) {
         : [printWithItem(path, print)];
 
       return concat([
-        group(concat(["with", line, join(",", items), ":"])),
+        group(concat(["with", line, join(", ", items), ":"])),
         indent(concat([hardline, printBody(path, print)]))
       ]);
     }

--- a/tests/python_with/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_with/__snapshots__/jsfmt.spec.js.snap
@@ -37,7 +37,7 @@ with open("tmp/index.html") as f:
 with open("tmp/index.html"):
     print("great")
 
-with A() as X,B() as Y,C() as Z:
+with A() as X, B() as Y, C() as Z:
     do_something()
 
 `;


### PR DESCRIPTION
I think there should be a space after the commas