### PR TITLE
Default print width to 79

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -149,6 +149,7 @@ module.exports = {
   parsers,
   options,
   defaultOptions: {
+    printWidth: 79,
     tabWidth: 4
   }
 };

--- a/tests/python_print_width/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_print_width/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`print_width.py 1`] = `
+def foo():
+    return "line_with_79_chars_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    return "line_with_80_chars_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+def foo():
+    return "line_with_79_chars_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    return \\
+        "line_with_80_chars_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+`;
+
+exports[`print_width.py 2`] = `
+def foo():
+    return "line_with_79_chars_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    return "line_with_80_chars_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+def foo():
+    return "line_with_79_chars_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    return \\
+        "line_with_80_chars_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+`;

--- a/tests/python_print_width/jsfmt.spec.js
+++ b/tests/python_print_width/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname, ["python"], { pythonVersion: "2" });
+run_spec(__dirname, ["python"], { pythonVersion: "3" });

--- a/tests/python_print_width/print_width.py
+++ b/tests/python_print_width/print_width.py
@@ -1,0 +1,3 @@
+def foo():
+    return "line_with_79_chars_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    return "line_with_80_chars_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"


### PR DESCRIPTION
To be consistent with PEP8, set the default column margin to 79 characters. Add tests to check that 79 characters fits on one line but 80 characters breaks to another line.

Fixes https://github.com/prettier/plugin-python/issues/14