### PR TITLE
Handle Python 2 `with` blocks and wrapping of `with` items

### DIFF
--- a/tests/python_with/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_with/__snapshots__/jsfmt.spec.js.snap
@@ -8,17 +8,39 @@ with open('tmp/index.html'):
     print('great')
 
 with A() as X, B() as Y, C() as Z:
-    do_something()~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    do_something()
+
+with A() as X:
+    with B() as Y:
+        with C() as Z:
+            do_something()
+
+with long_context_manager_1_aaaaaa, long_context_manager_1_aaaaaa, long_context_manager_1_aaaaaa: pass
+
+with long_context_manager_1_aaaaaa, long_context_manager_1_aaaaaa: long_function_name()
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 with open("tmp/index.html") as f:
     index = f.read()
 
 with open("tmp/index.html"):
     print("great")
 
+with A() as X, B() as Y, C() as Z:
+    do_something()
+
 with A() as X:
     with B() as Y:
         with C() as Z:
             do_something()
+
+with \\
+        long_context_manager_1_aaaaaa, \\
+        long_context_manager_1_aaaaaa, \\
+        long_context_manager_1_aaaaaa:
+    pass
+
+with long_context_manager_1_aaaaaa, long_context_manager_1_aaaaaa:
+    long_function_name()
 
 `;
 
@@ -30,7 +52,17 @@ with open('tmp/index.html'):
     print('great')
 
 with A() as X, B() as Y, C() as Z:
-    do_something()~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    do_something()
+
+with A() as X:
+    with B() as Y:
+        with C() as Z:
+            do_something()
+
+with long_context_manager_1_aaaaaa, long_context_manager_1_aaaaaa, long_context_manager_1_aaaaaa: pass
+
+with long_context_manager_1_aaaaaa, long_context_manager_1_aaaaaa: long_function_name()
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 with open("tmp/index.html") as f:
     index = f.read()
 
@@ -39,5 +71,19 @@ with open("tmp/index.html"):
 
 with A() as X, B() as Y, C() as Z:
     do_something()
+
+with A() as X:
+    with B() as Y:
+        with C() as Z:
+            do_something()
+
+with \\
+        long_context_manager_1_aaaaaa, \\
+        long_context_manager_1_aaaaaa, \\
+        long_context_manager_1_aaaaaa:
+    pass
+
+with long_context_manager_1_aaaaaa, long_context_manager_1_aaaaaa:
+    long_function_name()
 
 `;

--- a/tests/python_with/with.py
+++ b/tests/python_with/with.py
@@ -6,3 +6,12 @@ with open('tmp/index.html'):
 
 with A() as X, B() as Y, C() as Z:
     do_something()
+
+with A() as X:
+    with B() as Y:
+        with C() as Z:
+            do_something()
+
+with long_context_manager_1_aaaaaa, long_context_manager_1_aaaaaa, long_context_manager_1_aaaaaa: pass
+
+with long_context_manager_1_aaaaaa, long_context_manager_1_aaaaaa: long_function_name()


### PR DESCRIPTION
This diff handles Python 2's de-sugaring of a single `with` block's items into multiple nested AST nodes and is able to distinguish that case and reproduce accurate output based on the input code. It also handles wrapping long `with` blocks with many items.

Fixes https://github.com/prettier/plugin-python/issues/51