### PR TITLE
Wrap `assert` correctly

### DIFF
--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -1111,13 +1111,20 @@ function genericPrint(path, options, print) {
     }
 
     case "Assert": {
-      const parts = ["assert", line, path.call(print, "test")];
+      const predicate = groupConcat([
+        "assert",
+        indentConcat([escapedLine, path.call(print, "test")])
+      ]);
 
-      if (n.msg) {
-        parts.push(",", line, path.call(print, "msg"));
+      if (!n.msg) {
+        return predicate;
       }
 
-      return group(concat(parts));
+      return groupConcat([
+        predicate,
+        ",",
+        indentConcat([escapedLine, path.call(print, "msg")])
+      ]);
     }
 
     case "Yield": {

--- a/tests/python_assert/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_assert/__snapshots__/jsfmt.spec.js.snap
@@ -3,17 +3,49 @@
 exports[`assert.py 1`] = `
 assert 3 + 3
 assert False, 'message'
+
+assert my_long_predicate_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+assert my_long_predicate_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, "message"
+
+assert predicate, "my_long_message_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 assert 3 + 3
 assert False, "message"
+
+assert \\
+    my_long_predicate_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+assert \\
+    my_long_predicate_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, \\
+    "message"
+
+assert predicate, \\
+    "my_long_message_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 `;
 
 exports[`assert.py 2`] = `
 assert 3 + 3
 assert False, 'message'
+
+assert my_long_predicate_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+assert my_long_predicate_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, "message"
+
+assert predicate, "my_long_message_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 assert 3 + 3
 assert False, "message"
+
+assert \\
+    my_long_predicate_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+assert \\
+    my_long_predicate_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, \\
+    "message"
+
+assert predicate, \\
+    "my_long_message_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 `;

--- a/tests/python_assert/assert.py
+++ b/tests/python_assert/assert.py
@@ -1,2 +1,8 @@
 assert 3 + 3
 assert False, 'message'
+
+assert my_long_predicate_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+assert my_long_predicate_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, "message"
+
+assert predicate, "my_long_message_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"


### PR DESCRIPTION
This diff escapes line breaks used with `assert` and indents the wrapped portions.