### PR TITLE
Group multiline expressions with parens, fix multiline string escaping

### DIFF
--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -371,15 +371,13 @@ function printIf(path, print) {
   const parts = [
     type,
     " ",
-    group(
-      concat([
-        ifBreak("("),
-        indent(indent(path.call(print, "test"))),
-        ifBreak(")")
-      ])
-    ),
+    groupConcat([
+      ifBreak("("),
+      indent(indent(path.call(print, "test"))),
+      ifBreak(")")
+    ]),
     ":",
-    indent(concat([hardline, printBody(path, print)]))
+    indentConcat([hardline, printBody(path, print)])
   ];
 
   if (n.orelse.length) {
@@ -609,14 +607,12 @@ function genericPrint(path, options, print) {
     case "Expr": {
       if (n.value) {
         if (n.value.ast_type === "BoolOp" || n.value.ast_type === "BinOp") {
-          return group(
-            concat([
-              ifBreak("("),
-              indent(concat([softline, path.call(print, "value")])),
-              softline,
-              ifBreak(")")
-            ])
-          );
+          return groupConcat([
+            ifBreak("("),
+            indentConcat([softline, path.call(print, "value")]),
+            softline,
+            ifBreak(")")
+          ]);
         }
       }
       return path.call(print, "value");
@@ -1128,14 +1124,12 @@ function genericPrint(path, options, print) {
           n.value.ast_type === "Str"
         ) {
           parts.push(
-            group(
-              concat([
-                ifBreak(" (", " "),
-                indent(concat([softline, path.call(print, "value")])),
-                softline,
-                ifBreak(")")
-              ])
-            )
+            groupConcat([
+              ifBreak(" (", " "),
+              indentConcat([softline, path.call(print, "value")]),
+              softline,
+              ifBreak(")")
+            ])
           );
         } else {
           parts.push(indentConcat([escapedLine, path.call(print, "value")]));

--- a/src/printer/index.js
+++ b/src/printer/index.js
@@ -124,7 +124,7 @@ function hasMultipleStrings(rawContent, openingQuote) {
 function printTry(print, path) {
   return [
     "try:",
-    indent(concat([hardline, printBody(path, print)])),
+    indentConcat([hardline, printBody(path, print)]),
     hardline,
     join(hardline, path.map(print, "handlers"))
   ];
@@ -350,7 +350,7 @@ function printWithItem(path, print) {
     parts.push(line, "as", line, path.call(print, "optional_vars"));
   }
 
-  return group(concat(parts));
+  return groupConcat(parts);
 }
 
 function printIf(path, print) {
@@ -669,14 +669,14 @@ function genericPrint(path, options, print) {
       const parts = [
         printForIn(path, print),
         ":",
-        indent(concat([hardline, printBody(path, print)]))
+        indentConcat([hardline, printBody(path, print)])
       ];
 
       if (n.orelse.length > 0) {
         parts.push(
           line,
           "else:",
-          indent(concat([line, concat(path.map(print, "orelse"))]))
+          indentConcat([line, concat(path.map(print, "orelse"))])
         );
       }
 
@@ -724,7 +724,7 @@ function genericPrint(path, options, print) {
           parts.push(
             groupConcat([
               ifBreak("("),
-              indent(concat([softline, path.call(print, "value")])),
+              indentConcat([softline, path.call(print, "value")]),
               softline,
               ifBreak(")")
             ])
@@ -834,7 +834,7 @@ function genericPrint(path, options, print) {
         n.name,
         concat(bases),
         ":",
-        indent(concat([hardline, printBody(path, print)]))
+        indentConcat([hardline, printBody(path, print)])
       );
 
       return concat(parts);
@@ -893,7 +893,7 @@ function genericPrint(path, options, print) {
         "while ",
         path.call(print, "test"),
         ":",
-        indent(concat([hardline, printBody(path, print)]))
+        indentConcat([hardline, printBody(path, print)])
       ]);
     }
 
@@ -1047,7 +1047,7 @@ function genericPrint(path, options, print) {
         parts.push(
           hardline,
           "else:",
-          indent(concat([hardline, concat(path.map(print, "orelse"))]))
+          indentConcat([hardline, concat(path.map(print, "orelse"))])
         );
       }
 
@@ -1055,7 +1055,7 @@ function genericPrint(path, options, print) {
         parts.push(
           hardline,
           "finally:",
-          indent(concat([hardline, concat(path.map(print, "finalbody"))]))
+          indentConcat([hardline, concat(path.map(print, "finalbody"))])
         );
       }
 
@@ -1069,7 +1069,7 @@ function genericPrint(path, options, print) {
         parts.push(
           hardline,
           "finally:",
-          indent(concat([hardline, concat(path.map(print, "finalbody"))]))
+          indentConcat([hardline, concat(path.map(print, "finalbody"))])
         );
       }
 
@@ -1094,8 +1094,8 @@ function genericPrint(path, options, print) {
       parts.push(":");
 
       return concat([
-        group(concat(parts)),
-        indent(concat([hardline, printBody(path, print)]))
+        groupConcat(parts),
+        indentConcat([hardline, printBody(path, print)])
       ]);
     }
 
@@ -1233,7 +1233,7 @@ function genericPrint(path, options, print) {
     }
 
     case "Await": {
-      return group(concat(["await", " ", path.call(print, "value")]));
+      return groupConcat(["await", " ", path.call(print, "value")]);
     }
 
     case "Lambda": {
@@ -1263,7 +1263,7 @@ function genericPrint(path, options, print) {
 
       parts.push(path.call(print, "value"));
 
-      return group(concat(parts));
+      return groupConcat(parts);
     }
 
     case "Starred": {

--- a/tests/python_bin_op/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_bin_op/__snapshots__/jsfmt.spec.js.snap
@@ -3,17 +3,21 @@
 exports[`bin_op.py 1`] = `
 'LONG_STRING AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA %s' % my_long_variable_i
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-"LONG_STRING AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA %s" \\
-% \\
-my_long_variable_i
+(
+    "LONG_STRING AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA %s"
+    %
+    my_long_variable_i
+)
 
 `;
 
 exports[`bin_op.py 2`] = `
 'LONG_STRING AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA %s' % my_long_variable_i
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-"LONG_STRING AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA %s" \\
-% \\
-my_long_variable_i
+(
+    "LONG_STRING AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA %s"
+    %
+    my_long_variable_i
+)
 
 `;

--- a/tests/python_bool_op/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_bool_op/__snapshots__/jsfmt.spec.js.snap
@@ -9,11 +9,11 @@ my_long_variable_i and my_long_variable_j and 'LONG_STRING' in my_long_variable_
 data.retweeted or "RT @" in data.text
 data.retweeted and "RT @" in data.text
 
-my_long_variable_i \\
-and \\
-my_long_variable_j \\
-and \\
-"LONG_STRING" in my_long_variable_i.my_long_attribute_k
+(
+    my_long_variable_i and
+    my_long_variable_j and
+    "LONG_STRING" in my_long_variable_i.my_long_attribute_k
+)
 
 `;
 
@@ -26,10 +26,10 @@ my_long_variable_i and my_long_variable_j and 'LONG_STRING' in my_long_variable_
 data.retweeted or "RT @" in data.text
 data.retweeted and "RT @" in data.text
 
-my_long_variable_i \\
-and \\
-my_long_variable_j \\
-and \\
-"LONG_STRING" in my_long_variable_i.my_long_attribute_k
+(
+    my_long_variable_i and
+    my_long_variable_j and
+    "LONG_STRING" in my_long_variable_i.my_long_attribute_k
+)
 
 `;

--- a/tests/python_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_comments/__snapshots__/jsfmt.spec.js.snap
@@ -20,7 +20,7 @@ if a:  # a
         # post_migrate signals (which create ContentTypes).
     ]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-if a: # a
+if (a): # a
     # b
     c
 
@@ -60,7 +60,7 @@ if a:  # a
         # post_migrate signals (which create ContentTypes).
     ]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-if a: # a
+if (a): # a
     # b
     c
 

--- a/tests/python_if/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_if/__snapshots__/jsfmt.spec.js.snap
@@ -9,6 +9,9 @@ elif x == 12:
     print('oh')
 else:
     print(123)
+
+if (len(my_long_variable_my_long_variable) == 0 or len(my_long_variable_my_long_variable) == 1):
+    print("nice")
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 if x == "none":
     print("None")
@@ -18,6 +21,10 @@ elif x == 12:
     print("oh")
 else:
     print(123)
+
+if (len(my_long_variable_my_long_variable) == 0 or
+        len(my_long_variable_my_long_variable) == 1):
+    print("nice")
 
 `;
 
@@ -30,6 +37,9 @@ elif x == 12:
     print('oh')
 else:
     print(123)
+
+if (len(my_long_variable_my_long_variable) == 0 or len(my_long_variable_my_long_variable) == 1):
+    print("nice")
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 if x == "none":
     print("None")
@@ -39,5 +49,9 @@ elif x == 12:
     print("oh")
 else:
     print(123)
+
+if (len(my_long_variable_my_long_variable) == 0 or
+        len(my_long_variable_my_long_variable) == 1):
+    print("nice")
 
 `;

--- a/tests/python_if/if.py
+++ b/tests/python_if/if.py
@@ -6,3 +6,6 @@ elif x == 12:
     print('oh')
 else:
     print(123)
+
+if (len(my_long_variable_my_long_variable) == 0 or len(my_long_variable_my_long_variable) == 1):
+    print("nice")

--- a/tests/python_print_width/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_print_width/__snapshots__/jsfmt.spec.js.snap
@@ -7,8 +7,9 @@ def foo():
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 def foo():
     return "line_with_79_chars_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-    return \\
+    return (
         "line_with_80_chars_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    )
 
 `;
 
@@ -19,7 +20,8 @@ def foo():
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 def foo():
     return "line_with_79_chars_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-    return \\
+    return (
         "line_with_80_chars_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    )
 
 `;

--- a/tests/python_strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/python_strings/__snapshots__/jsfmt.spec.js.snap
@@ -24,6 +24,9 @@ a = """escaped triple quote \\""" in middle"""
 a = """other triple quote ''' in the middle"""
 a = '''other triple quote """ in the middle'''
 
+a = ("this SHOULD be re-flowed, but still a multi-line string "
+    "because it is very long and does not fit on one line")
+
 # The interior triple quotes don't get escaped properly
 # a = '''both triple quotes """ and \\''' in the middle'''
 # a = """both triple quotes ''' and \\""" in the middle"""
@@ -62,6 +65,19 @@ foo(
     '''this SHOULD NOT be re-flowed, but still a multi-line string '''
     """because it is very long and does not fit on one line"""
 )
+
+def foo():
+    return (
+        "this SHOULD be re-flowed, but still a multi-line string "
+        "because it is very long and does not fit on one line"
+    )
+
+my_dict["this SHOULD be re-flowed, but still a multi-line string "
+    "because it is very long and does not fit on one line"]
+
+
+"this SHOULD remain a multi-line string "
+"it is very long and does not fit on one line"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 a = 'it is "ok"'
 a = "it is 'ok'"
@@ -85,6 +101,11 @@ a = '''escaped triple quote """ in middle'''
 
 a = """other triple quote ''' in the middle"""
 a = '''other triple quote """ in the middle'''
+
+a = (
+    "this SHOULD be re-flowed, but still a multi-line string "
+    "because it is very long and does not fit on one line"
+)
 
 # The interior triple quotes don't get escaped properly
 # a = '''both triple quotes """ and \\''' in the middle'''
@@ -119,6 +140,23 @@ foo('this SHOULD be re-flowed, but still a multi-line string '
 foo('''this SHOULD NOT be re-flowed, but still a multi-line string '''
     """because it is very long and does not fit on one line""")
 
+
+def foo():
+    return (
+        "this SHOULD be re-flowed, but still a multi-line string "
+        "because it is very long and does not fit on one line"
+    )
+
+
+my_dict[
+    "this SHOULD be re-flowed, but still a multi-line string "
+    "because it is very long and does not fit on one line"
+]
+
+
+"this SHOULD remain a multi-line string "
+"it is very long and does not fit on one line"
+
 `;
 
 exports[`strings.py 2`] = `
@@ -144,6 +182,9 @@ a = """escaped triple quote \\""" in middle"""
 
 a = """other triple quote ''' in the middle"""
 a = '''other triple quote """ in the middle'''
+
+a = ("this SHOULD be re-flowed, but still a multi-line string "
+    "because it is very long and does not fit on one line")
 
 # The interior triple quotes don't get escaped properly
 # a = '''both triple quotes """ and \\''' in the middle'''
@@ -183,6 +224,19 @@ foo(
     '''this SHOULD NOT be re-flowed, but still a multi-line string '''
     """because it is very long and does not fit on one line"""
 )
+
+def foo():
+    return (
+        "this SHOULD be re-flowed, but still a multi-line string "
+        "because it is very long and does not fit on one line"
+    )
+
+my_dict["this SHOULD be re-flowed, but still a multi-line string "
+    "because it is very long and does not fit on one line"]
+
+
+"this SHOULD remain a multi-line string "
+"it is very long and does not fit on one line"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 a = 'it is "ok"'
 a = "it is 'ok'"
@@ -206,6 +260,11 @@ a = '''escaped triple quote """ in middle'''
 
 a = """other triple quote ''' in the middle"""
 a = '''other triple quote """ in the middle'''
+
+a = (
+    "this SHOULD be re-flowed, but still a multi-line string "
+    "because it is very long and does not fit on one line"
+)
 
 # The interior triple quotes don't get escaped properly
 # a = '''both triple quotes """ and \\''' in the middle'''
@@ -238,5 +297,22 @@ foo('this SHOULD be re-flowed, but still a multi-line string '
 
 foo('''this SHOULD NOT be re-flowed, but still a multi-line string '''
     """because it is very long and does not fit on one line""")
+
+
+def foo():
+    return (
+        "this SHOULD be re-flowed, but still a multi-line string "
+        "because it is very long and does not fit on one line"
+    )
+
+
+my_dict[
+    "this SHOULD be re-flowed, but still a multi-line string "
+    "because it is very long and does not fit on one line"
+]
+
+
+"this SHOULD remain a multi-line string "
+"it is very long and does not fit on one line"
 
 `;

--- a/tests/python_strings/strings.py
+++ b/tests/python_strings/strings.py
@@ -21,6 +21,9 @@ a = """escaped triple quote \""" in middle"""
 a = """other triple quote ''' in the middle"""
 a = '''other triple quote """ in the middle'''
 
+a = ("this SHOULD be re-flowed, but still a multi-line string "
+    "because it is very long and does not fit on one line")
+
 # The interior triple quotes don't get escaped properly
 # a = '''both triple quotes """ and \''' in the middle'''
 # a = """both triple quotes ''' and \""" in the middle"""
@@ -59,3 +62,16 @@ foo(
     '''this SHOULD NOT be re-flowed, but still a multi-line string '''
     """because it is very long and does not fit on one line"""
 )
+
+def foo():
+    return (
+        "this SHOULD be re-flowed, but still a multi-line string "
+        "because it is very long and does not fit on one line"
+    )
+
+my_dict["this SHOULD be re-flowed, but still a multi-line string "
+    "because it is very long and does not fit on one line"]
+
+
+"this SHOULD remain a multi-line string "
+"it is very long and does not fit on one line"


### PR DESCRIPTION
My attempt at a follow-up from https://github.com/prettier/plugin-python/pull/72 – surrounding the printed output for BinOp/BoolOp nodes with parens instead of using escaped lines.

This also fixes multiline strings not being escaped properly when on the right-hand side of an assignment or return expression.