### PR TITLE
Throw python exec spawnSync errors

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -12,6 +12,16 @@ function parseText(text, pythonExecutable) {
     }
   );
 
+  const executionError = executionResult.error;
+
+  if (executionError) {
+    if (executionError.code === "ENOENT") {
+      throw new Error(`${pythonExecutable} was not found in your PATH`);
+    } else {
+      throw executionError;
+    }
+  }
+
   const error = executionResult.stderr.toString();
 
   if (error) {


### PR DESCRIPTION
To reduce confusion when the requested python executable is not in your PATH or some other possible errors from executing python. See #98.

Before w/ confusing TypeError:

```
➜  plugin-python git:(spawn-error) ✗ ./node_modules/.bin/prettier  --plugin=. --parser=python ./tests/python_assert/assert.py

[error] tests/python_assert/assert.py: TypeError: Cannot read property 'toString' of null
[error]     at parseText (/mnt/c/Users/Ryan/Documents/Code/plugin-python/src/parser.js:15:39)
[error]     at Object.parse (/mnt/c/Users/Ryan/Documents/Code/plugin-python/src/parser.js:26:27)
[error]     at Object.parse (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/src/main/parser.js:75:19)
[error]     at formatWithCursor (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/index.js:101:25)
[error]     at Object.formatWithCursor (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/index.js:402:12)
[error]     at format (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/src/cli/util.js:157:19)
[error]     at error (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/src/cli/util.js:380:16)
[error]     at filePaths.forEach.filePath (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/src/cli/util.js:322:7)
[error]     at Array.forEach (native)
[error]     at eachFilename (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/src/cli/util.js:321:15)
[error]     at Object.formatFiles (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/src/cli/util.js:338:3)
[error]     at Object.run (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/src/cli/index.js:60:12)
[error]     at Object.<anonymous> (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/bin/prettier.js:5:23)
[error]     at Module._compile (module.js:570:32)
[error]     at Object.Module._extensions..js (module.js:579:10)
[error]     at Module.load (module.js:487:32)
```

After with this change:

```
➜  plugin-python git:(spawn-error) ./node_modules/.bin/prettier  --plugin=. --parser=python ./tests/python_assert/assert.py

[error] tests/python_assert/assert.py: Error: python3 was not found in your PATH
[error]     at parseText (/mnt/c/Users/Ryan/Documents/Code/plugin-python/src/parser.js:19:13)
[error]     at Object.parse (/mnt/c/Users/Ryan/Documents/Code/plugin-python/src/parser.js:36:27)
[error]     at Object.parse (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/src/main/parser.js:75:19)
[error]     at formatWithCursor (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/index.js:101:25)
[error]     at Object.formatWithCursor (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/index.js:402:12)
[error]     at format (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/src/cli/util.js:157:19)
[error]     at error (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/src/cli/util.js:380:16)
[error]     at filePaths.forEach.filePath (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/src/cli/util.js:322:7)
[error]     at Array.forEach (native)
[error]     at eachFilename (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/src/cli/util.js:321:15)
[error]     at Object.formatFiles (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/src/cli/util.js:338:3)
[error]     at Object.run (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/src/cli/index.js:60:12)
[error]     at Object.<anonymous> (/mnt/c/Users/Ryan/Documents/Code/plugin-python/node_modules/prettier/bin/prettier.js:5:23)
[error]     at Module._compile (module.js:570:32)
[error]     at Object.Module._extensions..js (module.js:579:10)
[error]     at Module.load (module.js:487:32)
```